### PR TITLE
fix: add env variables for GitHub secrets in workflow

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -36,6 +36,9 @@ jobs:
   validate:
     name: Validate Environment
     runs-on: ubuntu-latest
+    env:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     outputs:
       should_deploy: ${{ steps.validate.outputs.should_deploy }}
     steps:
@@ -48,14 +51,14 @@ jobs:
           echo "Validating required secrets..."
           
           # Check if SSH key is available
-          if [ -z "${{ secrets.SSH_PRIVATE_KEY }}" ]; then
+          if [ -z "${SSH_PRIVATE_KEY}" ]; then
             echo "❌ SSH_PRIVATE_KEY secret is missing"
             echo "should_deploy=false" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           # Check if bot token is available
-          if [ -z "${BOT_TOKEN:-}" ]; then
+          if [ -z "${BOT_TOKEN}" ]; then
             echo "❌ BOT_TOKEN secret is missing"
             echo "should_deploy=false" >> $GITHUB_OUTPUT
             exit 1
@@ -150,6 +153,9 @@ jobs:
     needs: [validate, test, build]
     if: always() && needs.validate.outputs.should_deploy == 'true' && (needs.test.result == 'success' || github.event.inputs.skip_tests == 'true' || github.event.inputs.force_deploy == 'true')
     environment: ${{ github.event.inputs.environment }}
+    env:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -282,6 +288,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     if: failure() && github.event.inputs.environment == 'production'
+    env:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     steps:
       - name: Set up SSH key
         uses: webfactory/ssh-agent@v0.9.0


### PR DESCRIPTION
- Add BOT_TOKEN and SSH_PRIVATE_KEY to env section in validate, deploy, and rollback jobs
- Fix secret validation to use environment variables instead of direct secrets access
- Resolves issue where BOT_TOKEN was always considered missing despite being set in repository secrets